### PR TITLE
until UM-set logic is repaired, disable writing to slim.conf

### DIFF
--- a/UM-set
+++ b/UM-set
@@ -41,22 +41,22 @@ function password {
     sed -ir "s/^$USER:[^:]\+/$USER:$entry/" /etc/shadow
     case $AUTOLOGIN in
     True)
-    sed -ir "s/.*auto_login.*./auto_login    yes/" /etc/slim.conf ;
+    #sed -ir "s/.*auto_login.*./auto_login    yes/" /etc/slim.conf ;
     DEFAULTUSER="True";
     AUTOLOGIN_CHANGE=" to autologin";
     ;;
     False)
-    sed -ir "s/.*auto_login.*./#auto_login    yes/" /etc/slim.conf ;
+    #sed -ir "s/.*auto_login.*./#auto_login    yes/" /etc/slim.conf ;
     AUTOLOGIN_CHANGE="";
     ;;
     esac
     case $DEFAULTUSER in
     True)
-    sed -ir "s/.*default_user.*./default_user    $USER/" /etc/slim.conf;
+    #sed -ir "s/.*default_user.*./default_user    $USER/" /etc/slim.conf;
     DEFAULTUSER_CHANGE="default user ($USER) set";
     ;;
     False)
-    sed -ir "s/.*default_user.*./#default_user    $USER/" /etc/slim.conf;
+    #sed -ir "s/.*default_user.*./#default_user    $USER/" /etc/slim.conf;
     DEFAULTUSER_CHANGE="";
     ;;
     esac

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,7 @@ Priority: optional
 Maintainer: anticapitalista <antix@operamail.com>
 Build-Depends: debhelper (>= 9.20120115)
 Standards-Version: 3.9.4
-Homepage: http://antix.mepis.org
-
+Homepage: https://github.com/antiX-Linux/user-management-antix
 Package: user-management-antix
 Depends: yad, gtkdialog, adduser, passwd, tar 
 Architecture: all

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,6 @@ Build-Depends: debhelper (>= 9.20120115)
 Standards-Version: 3.9.4
 Homepage: https://github.com/antiX-Linux/user-management-antix
 Package: user-management-antix
-Depends: yad, gtkdialog, adduser, passwd, tar 
+Depends: yad, adduser, passwd, tar 
 Architecture: all
 Description: Application to set up various user customisations for antiX.       


### PR DESCRIPTION
observed: Add user via /usr/local/bin/user-management and do NOT tick checkbox to request autologin.

undesirable result: UM-set disturbs slim.conf, setting the newly-added account name as default_user

Separate from the specific bug described above, the sed matchpatterns within the UM-set password() function need to revised so that matches are 1) more precise, and 2) are global (vs inline replacement of single occurrence). I am currently working on similar matchpattern improvements in the /usr/local/bin/slim-logon script (provided by package "slim-antix").