### PR TITLE
Repair handling of slim.conf

### DIFF
--- a/UM-set
+++ b/UM-set
@@ -39,27 +39,21 @@ function password {
     ADDUSER="$5";
     entry="$(mkpasswd -m sha-512 "$PASSWORD" | sed -r 's/([$/])/\\\1/g')"
     sed -ir "s/^$USER:[^:]\+/$USER:$entry/" /etc/shadow
-    case $AUTOLOGIN in
-    True)
-    #sed -ir "s/.*auto_login.*./auto_login    yes/" /etc/slim.conf ;
-    DEFAULTUSER="True";
-    AUTOLOGIN_CHANGE=" to autologin";
-    ;;
-    False)
-    #sed -ir "s/.*auto_login.*./#auto_login    yes/" /etc/slim.conf ;
-    AUTOLOGIN_CHANGE="";
-    ;;
-    esac
-    case $DEFAULTUSER in
-    True)
-    #sed -ir "s/.*default_user.*./default_user    $USER/" /etc/slim.conf;
-    DEFAULTUSER_CHANGE="default user ($USER) set";
-    ;;
-    False)
-    #sed -ir "s/.*default_user.*./#default_user    $USER/" /etc/slim.conf;
-    DEFAULTUSER_CHANGE="";
-    ;;
-    esac
+    if [ "$AUTOLOGIN" = "True" ]; then
+      DEFAULTUSER="True"
+      DEFAULTUSER_CHANGE="default user ($USER) set"
+      AUTOLOGIN_CHANGE=" to autologin"
+      sed -ir "s/^.\?default_user.*./default_user    $USER/" /etc/slim.conf
+      sed -ir "s/^.\?auto_login.*./auto_login    yes/" /etc/slim.conf 
+    elif [ "$DEFAULTUSER" = "True" ] && [ "$AUTOLOGIN" = "False" ]; then
+      DEFAULTUSER_CHANGE="default user ($USER) set"
+      AUTOLOGIN_CHANGE=" to no autologin"
+      sed -ir "s/^.\?default_user.*./default_user    $USER/" /etc/slim.conf
+      sed -ir "s/^.\?auto_login.*./#auto_login    yes/" /etc/slim.conf
+    else
+      DEFAULTUSER_CHANGE="No change to default user or";
+      AUTOLOGIN_CHANGE=" autologin";
+    fi
     
     yad --title="User-Management" --image="info" --text="$ADDUSER\nPassword set.\n$DEFAULTUSER_CHANGE$AUTOLOGIN_CHANGE"
 }

--- a/user-management
+++ b/user-management
@@ -147,17 +147,20 @@ class Password:
         loginbox = gtk.VBox()
         frame.add(loginbox)
         loginbox.show()
-        
+	
         self.defaultLogin = gtk.CheckButton()
         self.defaultLogin.set_label(_("Set as Default User"))
         loginbox.pack_start(self.defaultLogin)
+        self.defaultLogin.connect("clicked", lambda action :
+                                  self.autoLogin.set_sensitive(True))
         self.defaultLogin.show()
-        
+  
         self.autoLogin = gtk.CheckButton()
         self.autoLogin.set_label(_("Set User for Automatic Login"))
+        self.autoLogin.set_sensitive(False)
         loginbox.pack_start(self.autoLogin)
         self.autoLogin.show()
-        
+ 
         buttonbox = gtk.HButtonBox()
         vbox.pack_start(buttonbox)
         buttonbox.show()
@@ -278,10 +281,13 @@ class Add:
         self.defaultLogin = gtk.CheckButton()
         self.defaultLogin.set_label(_("Set as Default User"))
         loginbox.pack_start(self.defaultLogin)
+        self.defaultLogin.connect("clicked", lambda action :
+                                  self.autoLogin.set_sensitive(True))
         self.defaultLogin.show()
-        
+  
         self.autoLogin = gtk.CheckButton()
         self.autoLogin.set_label(_("Set User for Automatic Login"))
+        self.autoLogin.set_sensitive(False)
         loginbox.pack_start(self.autoLogin)
         self.autoLogin.show()
         
@@ -606,10 +612,13 @@ class Recover:
         self.defaultLogin = gtk.CheckButton()
         self.defaultLogin.set_label(_("Set as Default User"))
         loginbox.pack_start(self.defaultLogin)
+        self.defaultLogin.connect("clicked", lambda action :
+                                  self.autoLogin.set_sensitive(True))
         self.defaultLogin.show()
-        
+  
         self.autoLogin = gtk.CheckButton()
         self.autoLogin.set_label(_("Set User for Automatic Login"))
+        self.autoLogin.set_sensitive(False)
         loginbox.pack_start(self.autoLogin)
         self.autoLogin.show()
         


### PR DESCRIPTION
The patterns for changing the entries in slim.conf the are less permissive, and now only work at the start of a line so it won't mess up the comment on line 74 - (which also needs a leading '#' added).

There are only 3 cases - Make the user the default with no autologin, and make the user the default with autologin, or user is not default - no change to autologin.  

The UI be changed to reflect this,  eg only enable the autologin checkbox after default user has been clicked.
